### PR TITLE
chore(package): change le protocol à https

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "./node_modules/karma/bin/karma start karma.conf.js"
   },
   "dependencies": {
-    "o-utils": "git+ssh://git@github.com:lemonde/o-utils.git"
+    "o-utils": "https://github.com/lemonde/o-utils.git"
   },
   "devDependencies": {
     "babel-loader": "^5.3.2",


### PR DESCRIPTION
# Description

Le déploiement du **php-web-bff** était cassé sur l'infra à cause du protocol `git+ssh`.
On passe donc en protocol `https`.

# Recette

L'infra doit lancer un déploiement et tout dit bien se passer